### PR TITLE
Fix deprecated API

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function addCrossoriginAttrubuteToScripts(htmlPluginData, callback) {
     htmlPluginData.head.filter(filterScriptTags).forEach(addCrossoriginAttrubuteToScript);
     htmlPluginData.body.filter(filterScriptTags).forEach(addCrossoriginAttrubuteToScript);
 
-    callback(null);
+    callback(null, htmlPluginData);
 }
 
 function HtmlWebpackCrossoriginPlugin() {}


### PR DESCRIPTION
Return a result for the event "html-webpack-plugin-alter-asset-tags" to avoid the message:

> Using html-webpack-plugin-alter-asset-tags without returning a result is deprecated.